### PR TITLE
Configure eslint and update package.json urls

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -11,12 +11,14 @@ Move the preserve* packages from trufflesuite.
 - [ ] Build CHANGELOG.md
 - [ ] Set up husky
   - [ ] may need to run against history
+  - [x] eslint
+  - [ ] prettier
 - [ ] Establish github branch protection
   - [ ] Set master and develop workflow
 - [ ] Determine publishing method
   - [ ] Update publishing details 
     - [ ] admin info on npmjs
-    - [ ] package.json urls need to point this repo
+    - [x] package.json urls need to point this repo
   - [ ] GH CI based publish would be nice to have. 
     - [ ] may need conventional commits
     - [ ] should this monorepo respect independent versioning? which is


### PR DESCRIPTION
`eslintrc.json` is tagged as root so it can be used by all `preserve*` packages in the repo. I wasn't sure about what rules to apply or disable and went with options to make `lint .` not barf. This may not be the best choice for the project, comments and feedback appreciated.