### PR TITLE
Dependency update: Upgrade dependency: ipfs-http-client@56.0.2

### DIFF
--- a/packages/preserve-to-buckets/package.json
+++ b/packages/preserve-to-buckets/package.json
@@ -1,9 +1,19 @@
 {
   "name": "@truffle/preserve-to-buckets",
-  "version": "0.2.8",
   "description": "Truffle `preserve` command support for Textile Buckets",
+  "license": "MIT",
+  "author": "Rosco Kalis <roscokalis@gmail.com>",
+  "homepage": "https://github.com/trufflesuite/preserves/tree/master/packages/preserve-to-buckets#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/preserves.git",
+    "directory": "packages/preserve-to-buckets"
+  },
+  "bugs": {
+    "url": "https://github.com/trufflesuite/preserves/issues"
+  },
+  "version": "0.2.8",
   "main": "dist/lib/index.js",
-  "types": "dist/lib/index.d.ts",
   "files": [
     "dist",
     "truffle-plugin.json"
@@ -13,19 +23,15 @@
     "prepare": "yarn build",
     "test": "./scripts/test.sh"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/trufflesuite/preserves.git",
-    "directory": "packages/preserve-to-buckets"
-  },
-  "homepage": "https://github.com/trufflesuite/preserves/tree/master/packages/preserve-to-buckets#readme",
-  "bugs": {
-    "url": "https://github.com/trufflesuite/preserves/issues"
-  },
-  "author": "Rosco Kalis <roscokalis@gmail.com>",
-  "license": "MIT",
-  "publishConfig": {
-    "access": "public"
+  "types": "dist/lib/index.d.ts",
+  "dependencies": {
+    "@textile/hub": "^6.0.2",
+    "@truffle/preserve": "^0.2.7",
+    "cids": "^1.1.5",
+    "ipfs-http-client": "56.0.2",
+    "isomorphic-ws": "^4.0.1",
+    "iter-tools": "^7.0.2",
+    "ws": "^7.2.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.20",
@@ -36,13 +42,7 @@
     "ts-jest": "^26.5.0",
     "typescript": "4.2.4"
   },
-  "dependencies": {
-    "@textile/hub": "^6.0.2",
-    "@truffle/preserve": "^0.2.7",
-    "cids": "^1.1.5",
-    "ipfs-http-client": "^48.2.2",
-    "isomorphic-ws": "^4.0.1",
-    "iter-tools": "^7.0.2",
-    "ws": "^7.2.0"
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/preserve-to-ipfs/package.json
+++ b/packages/preserve-to-ipfs/package.json
@@ -1,9 +1,19 @@
 {
   "name": "@truffle/preserve-to-ipfs",
-  "version": "0.2.8",
   "description": "Truffle `preserve` command support for IPFS",
+  "license": "MIT",
+  "author": "g. nicholas d'andrea <gnidan@trufflesuite.com>",
+  "homepage": "https://github.com/trufflesuite/preserves/tree/master/packages/preserve-to-ipfs#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trufflesuite/preserves.git",
+    "directory": "packages/preserve-to-ipfs"
+  },
+  "bugs": {
+    "url": "https://github.com/trufflesuite/preserves/issues"
+  },
+  "version": "0.2.8",
   "main": "dist/lib/index.js",
-  "types": "dist/lib/index.d.ts",
   "files": [
     "dist",
     "truffle-plugin.json"
@@ -13,19 +23,11 @@
     "prepare": "yarn build",
     "test": "./scripts/test.sh"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/trufflesuite/preserves.git",
-    "directory": "packages/preserve-to-ipfs"
-  },
-  "homepage": "https://github.com/trufflesuite/preserves/tree/master/packages/preserve-to-ipfs#readme",
-  "bugs": {
-    "url": "https://github.com/trufflesuite/preserves/issues"
-  },
-  "author": "g. nicholas d'andrea <gnidan@trufflesuite.com>",
-  "license": "MIT",
-  "publishConfig": {
-    "access": "public"
+  "types": "dist/lib/index.d.ts",
+  "dependencies": {
+    "@truffle/preserve": "^0.2.7",
+    "ipfs-http-client": "56.0.2",
+    "iter-tools": "^7.0.2"
   },
   "devDependencies": {
     "@ganache/filecoin": "0.1.2",
@@ -38,9 +40,7 @@
     "ts-jest": "^26.5.0",
     "typescript": "4.2.4"
   },
-  "dependencies": {
-    "@truffle/preserve": "^0.2.7",
-    "ipfs-http-client": "^48.2.2",
-    "iter-tools": "^7.0.2"
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
I have not manually tested these changes but am relying on CI. If anyone has a suggestion on how to manually test this, please let me know.

* @truffle/preserve-to-buckets: ^48.2.2 →  56.0.2
* @truffle/preserve-to-ipfs: ^48.2.2 →  56.0.2